### PR TITLE
```

### DIFF
--- a/apps/api/api/index.ts
+++ b/apps/api/api/index.ts
@@ -187,6 +187,13 @@ const server = app.listen(port, async () => {
   }
 });
 
+// Configurer le timeout global du serveur immédiatement après sa création
+// Cela permet aux routes avec timeout personnalisé (3-4 minutes) de fonctionner correctement
+server.timeout = 300000; // 5 minutes (300 secondes)
+server.keepAliveTimeout = 305000; // 5 minutes + 5 secondes
+server.headersTimeout = 310000; // 5 minutes + 10 secondes
+console.log('Server timeout configured: 5 minutes (300000ms)');
+
 // Gestion propre de l'arrêt de l'application
 process.on('SIGTERM', async () => {
   console.log('SIGTERM received, shutting down gracefully...');

--- a/apps/api/api/routes/branding.routes.ts
+++ b/apps/api/api/routes/branding.routes.ts
@@ -143,8 +143,8 @@ brandingRoutes.post(
 
 // Middleware pour augmenter le timeout pour la génération de logo concepts
 const logoConceptsTimeout = (req: any, res: any, next: any) => {
-  req.setTimeout(180000); // 3 minutes
-  res.setTimeout(180000); // 3 minutes
+  req.setTimeout(240000); // 3 minutes
+  res.setTimeout(240000); // 3 minutes
   next();
 };
 
@@ -210,6 +210,13 @@ brandingRoutes.post(
   generateLogoConceptsController
 );
 
+// Middleware pour augmenter le timeout pour la génération de logo variations
+const logoVariationsTimeout = (req: any, res: any, next: any) => {
+  req.setTimeout(240000); // 4 minutes
+  res.setTimeout(240000); // 4 minutes
+  next();
+};
+
 // Étape 2: Generate logo variations for selected logo
 /**
  * @openapi
@@ -263,6 +270,7 @@ brandingRoutes.post(
   `/${resourceName}/generate/logo-variations/:projectId`,
   authenticate,
   checkQuota,
+  logoVariationsTimeout,
   generateLogoVariationsController
 );
 

--- a/apps/api/api/services/BandIdentity/branding.service.ts
+++ b/apps/api/api/services/BandIdentity/branding.service.ts
@@ -41,10 +41,10 @@ export class BrandingService extends GenericService {
     provider: LLMProvider.GEMINI,
     modelName: 'gemini-3-pro-preview', // Gemini 3 comme demandé
     llmOptions: {
-      maxOutputTokens: 2000, // Augmenté pour plus de détails SVG complexes
+      maxOutputTokens: 500, // Augmenté pour plus de détails SVG complexes
       temperature: 0.3, // Réduit pour cohérence et qualité constante
       topP: 0.9, // Augmenté pour diversité créative contrôlée
-      topK: 40, // Optimisé pour équilibre qualité/vitesse
+      topK: 30, // Optimisé pour équilibre qualité/vitesse
     },
   };
 


### PR DESCRIPTION
feat: increase server and endpoint timeouts to support longer logo generation operations

- Configured global server timeout to 5 minutes (300000ms) with keepAliveTimeout (305000ms) and headersTimeout (310000ms)
- Increased logo concepts generation timeout from 3 to 4 minutes (240000ms) for both request and response
- Added logoVariationsTimeout middleware with 4-minute timeout for logo variations endpoint
- Applied timeout middleware to /generate/logo-variations/:projectId endpoint
- Reduce