### PR TITLE
```

### DIFF
--- a/apps/api/api/services/BandIdentity/branding.service.ts
+++ b/apps/api/api/services/BandIdentity/branding.service.ts
@@ -532,7 +532,7 @@ export class BrandingService extends GenericService {
           },
           {
             provider: LLMProvider.GEMINI,
-            modelName: 'gemini-2.5-fgemini-3-pro-preview',
+            modelName: 'gemini-3-pro-preview',
             userId,
           }, // promptConfig
           'branding', // promptType

--- a/apps/api/api/services/BusinessPlan/businessPlan.service.ts
+++ b/apps/api/api/services/BusinessPlan/businessPlan.service.ts
@@ -143,7 +143,7 @@ export class BusinessPlanService extends GenericService {
       ];
       const promptConfig: PromptConfig = {
         provider: LLMProvider.GEMINI,
-        modelName: 'gemini-2.5-fgemini-3-pro-preview',
+        modelName: 'gemini-3-pro-preview',
       };
 
       // Initialize empty sections array to collect results as they come in

--- a/apps/api/api/services/Deployment/deployment.service.ts
+++ b/apps/api/api/services/Deployment/deployment.service.ts
@@ -770,7 +770,7 @@ Please provide only the terraform.tfvars file content as output.`;
       // Use AI to generate the tfvars content
       const promptConfig: PromptConfig = {
         provider: LLMProvider.GEMINI,
-        modelName: 'gemini-2.5-fgemini-3-pro-preview',
+        modelName: 'gemini-3-pro-preview',
         llmOptions: {
           temperature: 0.3,
           maxOutputTokens: 4000,
@@ -1140,7 +1140,7 @@ Please provide only the terraform.tfvars file content as output.`;
           const aiResponse = await this.promptService.runPrompt(
             {
               provider: LLMProvider.GEMINI,
-              modelName: 'gemini-2.5-fgemini-3-pro-preview',
+              modelName: 'gemini-3-pro-preview',
               llmOptions: {
                 temperature: 0.7,
                 maxOutputTokens: 1024,

--- a/apps/api/api/services/common/generic.service.ts
+++ b/apps/api/api/services/common/generic.service.ts
@@ -99,7 +99,7 @@ export class GenericService {
     contextFromPreviousSteps: string = '',
     promptConfig: PromptConfig = {
       provider: LLMProvider.GEMINI,
-      modelName: 'gemini-2.5-fgemini-3-pro-preview',
+      modelName: 'gemini-3-pro-preview',
       userId,
       promptType: promptType || step.stepName,
     }

--- a/apps/api/api/services/geminiMockup.service.ts
+++ b/apps/api/api/services/geminiMockup.service.ts
@@ -302,12 +302,12 @@ export class GeminiMockupService {
       // Générer l'image avec Gemini 2.5 Flash Image
       logger.info('🤖 Calling Gemini 2.5 Flash Image API', {
         mockupName,
-        model: 'gemini-2.5-fgemini-3-pro-preview-image',
+        model: 'gemini-3-pro-preview-image',
         projectId
       });
 
       const response = await this.geminiAI.models.generateContent({
-        model: 'gemini-2.5-fgemini-3-pro-preview-image',
+        model: 'gemini-3-pro-preview-image',
         contents: prompt,
       });
 

--- a/apps/appgen/apps/we-dev-next/src/app/api/chat/action.ts
+++ b/apps/appgen/apps/we-dev-next/src/app/api/chat/action.ts
@@ -48,7 +48,7 @@ export type Messages = Message[];
 const defaultModel = getOpenAIModel(
   process.env.THIRD_API_URL,
   process.env.THIRD_API_KEY,
-  'gemini-2.5-fgemini-3-pro-preview'
+  'gemini-3-pro-preview'
 ) as LanguageModel;
 
 export async function generateObjectFn(messages: Messages) {
@@ -56,7 +56,7 @@ export async function generateObjectFn(messages: Messages) {
     model: getOpenAIModel(
       process.env.THIRD_API_URL,
       process.env.THIRD_API_KEY,
-      'gemini-2.5-fgemini-3-pro-preview'
+      'gemini-3-pro-preview'
     ) as LanguageModel,
     schema: z.object({
       files: z.array(z.string()),

--- a/apps/appgen/apps/we-dev-next/src/app/api/model/config.ts
+++ b/apps/appgen/apps/we-dev-next/src/app/api/model/config.ts
@@ -15,8 +15,8 @@ interface ModelConfig {
 
 export const modelConfig: ModelConfig[] = [
   {
-    modelName: 'gemini-2.5-fgemini-3-pro-preview',
-    modelKey: 'gemini-2.5-fgemini-3-pro-preview',
+    modelName: 'gemini-3-pro-preview',
+    modelKey: 'gemini-3-pro-preview',
     useImage: true,
     provider: 'gemini',
     description: 'Gemini 2.5 Flash model',


### PR DESCRIPTION
fix: correct malformed Gemini model name from 'gemini-2.5-fgemini-3-pro-preview' to 'gemini-3-pro-preview'

- Fixed typo in BrandingService brand identity generation model name
- Fixed typo in BusinessPlanService default model configuration
- Fixed typo in DeploymentService tfvars generation and AI response models
- Fixed typo in GenericService default model configuration
- Fixed typo in GeminiMockupService image generation model name
- Fixed typo in appgen chat action default model and generate