### PR TITLE
```

### DIFF
--- a/apps/main-dashboard/.gitignore
+++ b/apps/main-dashboard/.gitignore
@@ -44,3 +44,6 @@ Thumbs.db
 
 # i18n split files (optional - uncomment to ignore split files)
 # /public/assets/i18n/split/*
+
+# ngx-extended-pdf-viewer assets (copied from node_modules)
+/src/assets/ngx-extended-pdf-viewer/

--- a/apps/main-dashboard/angular.json
+++ b/apps/main-dashboard/angular.json
@@ -25,7 +25,7 @@
               },
               {
                 "glob": "**/*",
-                "input": "../../node_modules/ngx-extended-pdf-viewer/assets/",
+                "input": "src/assets/ngx-extended-pdf-viewer/",
                 "output": "/assets/"
               }
             ],
@@ -96,7 +96,7 @@
               },
               {
                 "glob": "**/*",
-                "input": "../../node_modules/ngx-extended-pdf-viewer/assets/",
+                "input": "src/assets/ngx-extended-pdf-viewer/",
                 "output": "/assets/"
               }
             ],

--- a/apps/main-dashboard/package.json
+++ b/apps/main-dashboard/package.json
@@ -9,7 +9,9 @@
     "test": "ng test",
     "i18n:split": "node scripts/split-i18n.js",
     "i18n:merge": "node scripts/merge-i18n.js",
-    "i18n:split-merge": "npm run i18n:split && npm run i18n:merge"
+    "i18n:split-merge": "npm run i18n:split && npm run i18n:merge",
+    "copy:pdf-assets": "cd ../.. && ./apps/main-dashboard/scripts/copy-pdf-assets.sh",
+    "postinstall": "node scripts/postinstall.js"
   },
   "prettier": {
     "printWidth": 100,

--- a/apps/main-dashboard/scripts/copy-pdf-assets.sh
+++ b/apps/main-dashboard/scripts/copy-pdf-assets.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Script pour copier les assets de ngx-extended-pdf-viewer
+# À exécuter depuis la racine du monorepo
+
+set -e
+
+echo "🔄 Copie des assets ngx-extended-pdf-viewer..."
+
+# Vérifier que nous sommes à la racine du monorepo
+if [ ! -f "package.json" ] || [ ! -d "apps/main-dashboard" ]; then
+    echo "❌ Ce script doit être exécuté depuis la racine du monorepo"
+    exit 1
+fi
+
+# Créer le dossier de destination
+mkdir -p apps/main-dashboard/src/assets/ngx-extended-pdf-viewer
+
+# Copier les assets
+if [ -d "node_modules/ngx-extended-pdf-viewer/assets" ]; then
+    cp -r node_modules/ngx-extended-pdf-viewer/assets/* apps/main-dashboard/src/assets/ngx-extended-pdf-viewer/
+    echo "✅ Assets copiés avec succès"
+
+    # Afficher la taille des assets copiés
+    echo "📊 Taille des assets :"
+    du -sh apps/main-dashboard/src/assets/ngx-extended-pdf-viewer/
+else
+    echo "❌ Dossier node_modules/ngx-extended-pdf-viewer/assets introuvable"
+    echo "💡 Exécutez 'npm install' d'abord"
+    exit 1
+fi
+
+echo "🎉 Copie terminée !"

--- a/apps/main-dashboard/scripts/postinstall.js
+++ b/apps/main-dashboard/scripts/postinstall.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+/**
+ * Script post-install pour main-dashboard
+ * Copie automatiquement les assets ngx-extended-pdf-viewer après npm install
+ */
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+console.log('🔧 Post-install main-dashboard...');
+
+// Vérifier si nous sommes dans le bon contexte
+const isInMainDashboard = process.cwd().includes('main-dashboard');
+const rootPath = isInMainDashboard ? '../..' : '.';
+
+// Chemins
+const nodeModulesPath = path.join(rootPath, 'node_modules/ngx-extended-pdf-viewer/assets');
+const targetPath = path.join(isInMainDashboard ? '.' : 'apps/main-dashboard', 'src/assets/ngx-extended-pdf-viewer');
+
+try {
+    // Vérifier si les assets source existent
+    if (!fs.existsSync(nodeModulesPath)) {
+        console.log('⚠️  Assets ngx-extended-pdf-viewer non trouvés, ignoré');
+        process.exit(0);
+    }
+
+    // Créer le dossier de destination
+    if (!fs.existsSync(targetPath)) {
+        fs.mkdirSync(targetPath, { recursive: true });
+    }
+
+    // Copier les assets
+    console.log('📦 Copie des assets ngx-extended-pdf-viewer...');
+
+    if (process.platform === 'win32') {
+        execSync(`xcopy "${nodeModulesPath}" "${targetPath}" /E /I /Y`, { stdio: 'inherit' });
+    } else {
+        execSync(`cp -r "${nodeModulesPath}"/* "${targetPath}"/`, { stdio: 'inherit' });
+    }
+
+    console.log('✅ Assets ngx-extended-pdf-viewer copiés avec succès');
+
+} catch (error) {
+    console.error('❌ Erreur lors de la copie des assets:', error.message);
+    // Ne pas faire échouer l'installation pour autant
+    process.exit(0);
+}


### PR DESCRIPTION
feat: relocate ngx-extended-pdf-viewer assets from node_modules to src/assets directory

- Added /src/assets/ngx-extended-pdf-viewer/ to .gitignore to exclude copied PDF viewer assets
- Updated angular.json asset paths to reference src/assets/ngx-extended-pdf-viewer/ instead of node_modules
- Added copy:pdf-assets script to package.json for manual asset copying via shell script
- Added postinstall script to package.json to automatically copy PDF viewer assets after npm install
- Applied asset