### PR TITLE
```

### DIFF
--- a/Dockerfile.main-dashboard
+++ b/Dockerfile.main-dashboard
@@ -28,8 +28,9 @@ RUN npm run build
 # Stage de production avec nginx
 FROM nginx:alpine AS production
 
-# Copier la configuration nginx
+# Copier la configuration nginx et les MIME types
 COPY ./apps/main-dashboard/nginx.conf /etc/nginx/nginx.conf
+COPY ./apps/main-dashboard/mime.types.custom /etc/nginx/mime.types.custom
 
 # Copier le build de l'application
 COPY --from=builder /app/apps/main-dashboard/dist/main-dashboard/browser /usr/share/nginx/html

--- a/apps/main-dashboard/mime.types.custom
+++ b/apps/main-dashboard/mime.types.custom
@@ -1,0 +1,42 @@
+# MIME types personnalisés pour ngx-extended-pdf-viewer
+
+types {
+    # Types par défaut
+    text/html                             html htm shtml;
+    text/css                              css;
+    text/xml                              xml;
+    image/gif                             gif;
+    image/jpeg                            jpeg jpg;
+    image/png                             png;
+    image/svg+xml                         svg svgz;
+    image/webp                            webp;
+
+    # JavaScript et modules
+    application/javascript                js;
+    application/javascript                mjs;
+    text/javascript                       js mjs;
+
+    # WebAssembly
+    application/wasm                      wasm;
+
+    # Fonts
+    font/woff                             woff;
+    font/woff2                            woff2;
+    application/font-woff                 woff;
+    application/font-woff2                woff2;
+    font/ttf                              ttf;
+    font/otf                              otf;
+    application/vnd.ms-fontobject         eot;
+
+    # Archives et documents
+    application/pdf                       pdf;
+    application/zip                       zip;
+
+    # Autres
+    application/json                      json;
+    application/octet-stream              bin exe dll;
+    application/octet-stream              deb;
+    application/octet-stream              dmg;
+    application/octet-stream              iso img;
+    application/octet-stream              msi msp msm;
+}

--- a/apps/main-dashboard/nginx.conf
+++ b/apps/main-dashboard/nginx.conf
@@ -6,10 +6,17 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
+    # Ajouter les MIME types manquants pour PDF.js
+    map $uri $content_type_override {
+        ~\.mjs$ "application/javascript";
+        ~\.wasm$ "application/wasm";
+        default "";
+    }
+
     sendfile on;
     keepalive_timeout 65;
     gzip on;
-    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript application/wasm;
 
     server {
         listen 80;
@@ -22,10 +29,35 @@ http {
             try_files $uri $uri/ /index.html;
         }
 
-        # Cache pour les assets statiques
+        # Configuration spécifique pour les fichiers .mjs (modules JavaScript)
+        location ~* \.mjs$ {
+            add_header Content-Type "application/javascript" always;
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+        }
+
+        # Configuration spécifique pour les fichiers .wasm (WebAssembly)
+        location ~* \.wasm$ {
+            add_header Content-Type "application/wasm" always;
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+        }
+
+        # Assets statiques généraux
         location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
             expires 1y;
             add_header Cache-Control "public, immutable";
+        }
+
+        # Configuration spéciale pour le dossier assets (ngx-extended-pdf-viewer)
+        location /assets/ {
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+
+            # Permettre l'accès CORS si nécessaire
+            add_header Access-Control-Allow-Origin "*" always;
+            add_header Access-Control-Allow-Methods "GET, HEAD, OPTIONS" always;
+            add_header Access-Control-Allow-Headers "Range" always;
         }
     }
 }

--- a/test-nginx.sh
+++ b/test-nginx.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Test rapide de la configuration nginx
+
+echo "🔧 Test de la configuration nginx..."
+
+# Vérifier la syntaxe nginx
+echo "📝 Vérification de la syntaxe nginx..."
+docker run --rm -v "$(pwd)/apps/main-dashboard/nginx.conf:/etc/nginx/nginx.conf:ro" nginx:alpine nginx -t
+
+if [ $? -eq 0 ]; then
+    echo "✅ Configuration nginx valide"
+else
+    echo "❌ Erreur dans la configuration nginx"
+    exit 1
+fi
+
+echo "🎉 Test nginx terminé avec succès !"

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Script pour tester le build Docker de main-dashboard
+# Vérifie que les assets PDF sont correctement copiés
+
+set -e
+
+echo "🐳 Test du build Docker main-dashboard..."
+
+# Vérifier que nous sommes à la racine du monorepo
+if [ ! -f "package.json" ] || [ ! -f "Dockerfile.main-dashboard" ]; then
+    echo "❌ Ce script doit être exécuté depuis la racine du monorepo"
+    exit 1
+fi
+
+# Build l'image Docker
+echo "📦 Building Docker image..."
+docker build -f Dockerfile.main-dashboard -t idem-main-dashboard:test .
+
+# Créer un conteneur temporaire pour vérifier les assets
+echo "🔍 Vérification des assets PDF dans l'image..."
+CONTAINER_ID=$(docker create idem-main-dashboard:test)
+
+# Vérifier que les assets PDF sont présents dans le build
+echo "📁 Vérification de la structure des assets..."
+docker cp $CONTAINER_ID:/usr/share/nginx/html/assets/ ./temp-assets/ 2>/dev/null || {
+    echo "⚠️ Dossier assets non trouvé dans l'image"
+}
+
+if [ -d "./temp-assets" ]; then
+    if [ -f "./temp-assets/pdf.worker-5.4.803.mjs" ] || [ -f "./temp-assets/viewer-5.4.803.mjs" ]; then
+        echo "✅ Assets PDF trouvés dans l'image Docker !"
+        ls -la ./temp-assets/ | grep -E "\.(mjs|js)$" | head -5
+    else
+        echo "❌ Assets PDF manquants dans l'image Docker"
+        echo "📂 Contenu du dossier assets :"
+        ls -la ./temp-assets/ || echo "Dossier assets vide"
+    fi
+
+    # Nettoyer
+    rm -rf ./temp-assets/
+else
+    echo "❌ Impossible d'extraire les assets de l'image"
+fi
+
+# Nettoyer le conteneur
+docker rm $CONTAINER_ID >/dev/null
+
+echo "🎉 Test terminé !"
+echo "💡 Pour tester l'application : docker run -p 8080:80 idem-main-dashboard:test"


### PR DESCRIPTION
feat: configure nginx MIME types and caching for ngx-extended-pdf-viewer assets

- Added custom MIME types configuration file copy to Dockerfile.main-dashboard
- Added map directive in nginx.conf to override MIME types for .mjs and .wasm files
- Added application/wasm to gzip_types for WebAssembly compression
- Added specific location blocks for .mjs files with application/javascript content type
- Added specific location blocks for .wasm files with application/wasm content type
- Added dedicate