### PR TITLE
refactor: replace i18n translation keys with hardcoded French text in…

### DIFF
--- a/apps/main-dashboard/src/app/modules/dashboard/pages/create-project/create-project.html
+++ b/apps/main-dashboard/src/app/modules/dashboard/pages/create-project/create-project.html
@@ -85,7 +85,7 @@
           [project]="project()"
           [selectedLogo]="project().analysisResultModel.branding.logo.id || ''"
           [selectedColor]="project().analysisResultModel.branding.colors.id || ''"
-          [selectedTypography]="project().analysisResultModel?.branding?.typography?.id || ''"
+          [selectedTypography]="project().analysisResultModel!.branding!.typography!.id || ''"
           [logos]="project().analysisResultModel.branding.generatedLogos || []"
           [colorPalettes]="project().analysisResultModel.branding.generatedColors || []"
           [typographyOptions]="project().analysisResultModel.branding.generatedTypography || []"

--- a/apps/main-dashboard/src/app/modules/dashboard/pages/development/show-development/show-development.html
+++ b/apps/main-dashboard/src/app/modules/dashboard/pages/development/show-development/show-development.html
@@ -36,12 +36,13 @@
 
             <!-- Title -->
             <h1 class="text-5xl font-bold text-white text-glow-primary mb-4">
-              {{ 'dashboard.showDevelopment.landingPage.title' | translate }}
+              Votre Landing Page est Prête à Générer
             </h1>
 
             <!-- Description -->
             <p class="text-xl text-gray-300 mb-8 max-w-2xl mx-auto leading-relaxed">
-              {{ 'dashboard.showDevelopment.landingPage.subtitle' | translate }}
+              Votre configuration est finalisée. Lancez la génération pour créer votre landing page
+              professionnelle et moderne en quelques minutes.
             </p>
 
             <!-- Main CTA Button -->
@@ -54,9 +55,7 @@
                   d="M10.894 2.553a1 1 0 00-1.788 0l-7 14a1 1 0 001.169 1.409l5-1.429A1 1 0 009 15.571V11a1 1 0 112 0v4.571a1 1 0 00.725.962l5 1.428a1 1 0 001.17-1.408l-7-14z"
                 />
               </svg>
-              <span class="font-semibold">{{
-                'dashboard.showDevelopment.landingPage.cta' | translate
-              }}</span>
+              <span class="font-semibold">Générer ma Landing Page</span>
             </button>
 
             <!-- Features Preview -->
@@ -76,15 +75,8 @@
                       />
                     </svg>
                   </div>
-                  <h3 class="text-white font-semibold text-lg mb-2">
-                    {{ 'dashboard.showDevelopment.landingPage.features.modern.title' | translate }}
-                  </h3>
-                  <p class="text-gray-400 text-sm text-center">
-                    {{
-                      'dashboard.showDevelopment.landingPage.features.modern.description'
-                        | translate
-                    }}
-                  </p>
+                  <h3 class="text-white font-semibold text-lg mb-2">Design Moderne</h3>
+                  <p class="text-gray-400 text-sm text-center">Interface élégante et responsive</p>
                 </div>
               </div>
 
@@ -104,14 +96,8 @@
                       />
                     </svg>
                   </div>
-                  <h3 class="text-white font-semibold text-lg mb-2">
-                    {{ 'dashboard.showDevelopment.landingPage.features.seo.title' | translate }}
-                  </h3>
-                  <p class="text-gray-400 text-sm text-center">
-                    {{
-                      'dashboard.showDevelopment.landingPage.features.seo.description' | translate
-                    }}
-                  </p>
+                  <h3 class="text-white font-semibold text-lg mb-2">Optimisé SEO</h3>
+                  <p class="text-gray-400 text-sm text-center">Référencement naturel optimisé</p>
                 </div>
               </div>
 
@@ -128,17 +114,9 @@
                       />
                     </svg>
                   </div>
-                  <h3 class="text-white font-semibold text-lg mb-2">
-                    {{
-                      'dashboard.showDevelopment.landingPage.features.customizable.title'
-                        | translate
-                    }}
-                  </h3>
+                  <h3 class="text-white font-semibold text-lg mb-2">Personnalisable</h3>
                   <p class="text-gray-400 text-sm text-center">
-                    {{
-                      'dashboard.showDevelopment.landingPage.features.customizable.description'
-                        | translate
-                    }}
+                    Facilement modifiable selon vos besoins
                   </p>
                 </div>
               </div>
@@ -169,12 +147,13 @@
 
             <!-- Title -->
             <h1 class="text-4xl font-bold text-white text-glow-primary mb-4">
-              {{ 'dashboard.showDevelopment.title' | translate }}
+              Configuration prête
             </h1>
 
             <!-- Concise explanation -->
             <p class="text-lg text-gray-300 mb-8 max-w-2xl mx-auto">
-              {{ 'dashboard.showDevelopment.subtitle' | translate }}
+              Votre stack technologique est configurée. Lancez la génération pour créer votre
+              application complète.
             </p>
 
             <!-- Main CTA -->
@@ -182,7 +161,7 @@
               (click)="redirectToWebGenerator(projectId())"
               class="inner-button inline-flex items-center gap-3 text-lg px-8 py-4 mb-6 glow-accent"
             >
-              <span>{{ 'dashboard.showDevelopment.buttons.generate' | translate }}</span>
+              <span>Générer l'application</span>
             </button>
 
             <!-- Tech Stack Cards -->


### PR DESCRIPTION
… show-development page

Replace translation keys with hardcoded French text for title, subtitle, CTA button, and feature descriptions (modern design, SEO optimization, customization) in both landing page and standard views. Change optional chaining operator to non-null assertion operator for selectedTypography in create-project template.